### PR TITLE
feat: support fastify

### DIFF
--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -60,7 +60,7 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
 
     consumer
       .apply(MikroOrmMiddleware) // register request context automatically
-      .forRoutes({ path: '*', method: RequestMethod.ALL });
+      .forRoutes({ path: '(.*)', method: RequestMethod.ALL });
   }
 
 }

--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -3,9 +3,9 @@ import { DynamicModule, Global, Inject, MiddlewareConsumer, Module, OnApplicatio
 import { ModuleRef } from '@nestjs/core';
 
 import { MIKRO_ORM_MODULE_OPTIONS } from './mikro-orm.common';
-import { MikroOrmModuleAsyncOptions, MikroOrmModuleOptions } from './typings';
-import { createAsyncProviders, createMikroOrmEntityManagerProvider, createMikroOrmProvider } from './mikro-orm.providers';
 import { MikroOrmMiddleware } from './mikro-orm.middleware';
+import { createAsyncProviders, createMikroOrmEntityManagerProvider, createMikroOrmProvider } from './mikro-orm.providers';
+import { FastifyMiddlewareConsumer, MikroOrmModuleAsyncOptions, MikroOrmModuleOptions } from './typings';
 
 @Global()
 @Module({})
@@ -58,9 +58,19 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
       return;
     }
 
+    const isFastify = (
+      consumer: MiddlewareConsumer
+    ): consumer is FastifyMiddlewareConsumer =>
+      typeof (consumer as any).httpAdapter === 'object' &&
+      (consumer as any).httpAdapter.constructor.name
+        .toLowerCase()
+        .startsWith('fastify');
+
+    const forRoutesPath =
+      this.options.forRoutesPath ?? (isFastify(consumer) ? '(.*)' : '*');
+
     consumer
       .apply(MikroOrmMiddleware) // register request context automatically
-      .forRoutes({ path: '(.*)', method: RequestMethod.ALL });
+      .forRoutes({ path: forRoutesPath, method: RequestMethod.ALL });
   }
-
 }

--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -73,4 +73,5 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
       .apply(MikroOrmMiddleware) // register request context automatically
       .forRoutes({ path: forRoutesPath, method: RequestMethod.ALL });
   }
+
 }

--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -62,14 +62,14 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
     const isNestMiddleware = (
       consumer: MiddlewareConsumer
     ): consumer is NestMiddlewareConsumer =>
-      typeof (consumer as any).httpAdapter === "object";
+      typeof (consumer as any).httpAdapter === 'object';
 
     const usingFastify = (consumer: NestMiddlewareConsumer) =>
-      consumer.httpAdapter.constructor.name.toLowerCase().startsWith("fastify");
+      consumer.httpAdapter.constructor.name.toLowerCase().startsWith('fastify');
 
     const forRoutesPath =
       this.options.forRoutesPath ??
-      (isNestMiddleware(consumer) && usingFastify(consumer) ? "(.*)" : "*");
+      (isNestMiddleware(consumer) && usingFastify(consumer) ? '(.*)' : '*');
 
     consumer
       .apply(MikroOrmMiddleware) // register request context automatically

--- a/src/mikro-orm.module.ts
+++ b/src/mikro-orm.module.ts
@@ -1,14 +1,14 @@
-import { AnyEntity, EntityName, Options } from '@mikro-orm/core';
+import { AnyEntity, EntityName } from '@mikro-orm/core';
 import { DynamicModule, Module } from '@nestjs/common';
 
 import { createMikroOrmRepositoryProviders } from './mikro-orm.providers';
 import { MikroOrmCoreModule } from './mikro-orm-core.module';
-import { MikroOrmModuleAsyncOptions } from './typings';
+import { MikroOrmModuleAsyncOptions, MikroOrmModuleOptions } from './typings';
 
 @Module({})
 export class MikroOrmModule {
 
-  static forRoot(options?: Options): DynamicModule {
+  static forRoot(options?: MikroOrmModuleOptions): DynamicModule {
     return {
       module: MikroOrmModule,
       imports: [MikroOrmCoreModule.forRoot(options)],

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -2,7 +2,7 @@ import { Options, IDatabaseDriver } from '@mikro-orm/core';
 import { MiddlewareConsumer, ModuleMetadata, Type } from '@nestjs/common';
 
 export interface FastifyMiddlewareConsumer extends MiddlewareConsumer {
-  httpAdapter: object;
+  httpAdapter: Record<string, unknown>;
 }
 
 export type MikroOrmModuleOptions<D extends IDatabaseDriver = IDatabaseDriver> = {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,8 +1,9 @@
-import { Options, IDatabaseDriver } from '@mikro-orm/core';
+import { IDatabaseDriver, Options } from '@mikro-orm/core';
 import { MiddlewareConsumer, ModuleMetadata, Type } from '@nestjs/common';
+import { AbstractHttpAdapter } from '@nestjs/core';
 
-export interface FastifyMiddlewareConsumer extends MiddlewareConsumer {
-  httpAdapter: Record<string, unknown>;
+export interface NestMiddlewareConsumer extends MiddlewareConsumer {
+  httpAdapter: AbstractHttpAdapter;
 }
 
 export type MikroOrmModuleOptions<D extends IDatabaseDriver = IDatabaseDriver> = {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,17 +1,29 @@
-import { Options } from '@mikro-orm/core';
-import { ModuleMetadata, Type } from '@nestjs/common';
+import { Options, IDatabaseDriver } from '@mikro-orm/core';
+import { MiddlewareConsumer, ModuleMetadata, Type } from '@nestjs/common';
 
-export type MikroOrmModuleOptions = {
-  registerRequestContext?: boolean;
-} & Options;
-
-export interface MikroOrmOptionsFactory {
-  createMikroOrmOptions(): Promise<MikroOrmModuleOptions> | MikroOrmModuleOptions;
+export interface FastifyMiddlewareConsumer extends MiddlewareConsumer {
+  httpAdapter: object;
 }
 
-export interface MikroOrmModuleAsyncOptions extends Pick<ModuleMetadata, 'imports' | 'providers'> {
-  useExisting?: Type<MikroOrmOptionsFactory>;
-  useClass?: Type<MikroOrmOptionsFactory>;
-  useFactory?: (...args: any[]) => Promise<MikroOrmModuleOptions> | MikroOrmModuleOptions;
+export type MikroOrmModuleOptions<D extends IDatabaseDriver = IDatabaseDriver> = {
+  registerRequestContext?: boolean;
+  /**
+   * Routes to apply the middleware.
+   *
+   * For Fastify, the middleware applies to all routes using the RegExp `"(.*)"`.
+   *
+   * For all other frameworks including Express, the middleware applies to all routes using the RegExp `"*"`.
+   */
+  forRoutesPath?: string;
+} & Options<D>;
+
+export interface MikroOrmOptionsFactory<D extends IDatabaseDriver = IDatabaseDriver> {
+  createMikroOrmOptions(): Promise<MikroOrmModuleOptions<D>> | MikroOrmModuleOptions<D>;
+}
+
+export interface MikroOrmModuleAsyncOptions<D extends IDatabaseDriver = IDatabaseDriver> extends Pick<ModuleMetadata, 'imports' | 'providers'> {
+  useExisting?: Type<MikroOrmOptionsFactory<D>>;
+  useClass?: Type<MikroOrmOptionsFactory<D>>;
+  useFactory?: (...args: any[]) => Promise<MikroOrmModuleOptions<D>> | MikroOrmModuleOptions<D>;
   inject?: any[];
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -10,9 +10,9 @@ export type MikroOrmModuleOptions<D extends IDatabaseDriver = IDatabaseDriver> =
   /**
    * Routes to apply the middleware.
    *
-   * For Fastify, the middleware applies to all routes using the RegExp `"(.*)"`.
+   * For Fastify, the middleware applies to all routes using `(.*)`.
    *
-   * For all other frameworks including Express, the middleware applies to all routes using the RegExp `"*"`.
+   * For all other frameworks including Express, the middleware applies to all routes using `*`.
    */
   forRoutesPath?: string;
 } & Options<D>;


### PR DESCRIPTION
`path-to-regexp` [deprecated](https://github.com/pillarjs/path-to-regexp/blob/master/Readme.md#compatibility-with-express--4x) the usage of `*` for a wildcard route:

> No wildcard asterisk (\*) - use parameters instead ((.\*) or :splat*)

Closes: https://github.com/mikro-orm/nestjs/issues/3