### PR TITLE
simplify code when setting entity manger provider for knex or mongo

### DIFF
--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -37,8 +37,8 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
         { provide: MIKRO_ORM_MODULE_OPTIONS, useValue: options || {} },
         createMikroOrmProvider(contextName),
         createEntityManagerProvider(options?.scope, EntityManager, contextName),
-        ...(knex ? [createEntityManagerProvider(options?.scope, contextName ? getEntityManagerToken(contextName) : knex.SqlEntityManager, contextName)] : []),
-        ...(mongo ? [createEntityManagerProvider(options?.scope, contextName ? getEntityManagerToken(contextName) : mongo.MongoEntityManager, contextName)] : []),
+        ...(knex ? [createEntityManagerProvider(options?.scope, knex.SqlEntityManager, contextName)] : []),
+        ...(mongo ? [createEntityManagerProvider(options?.scope, mongo.MongoEntityManager, contextName)] : []),
       ],
       exports: [
         contextName ? getMikroORMToken(contextName) : MikroORM,
@@ -62,8 +62,8 @@ export class MikroOrmCoreModule implements OnApplicationShutdown {
         ...createAsyncProviders({ ...options, contextName: options.contextName }),
         createMikroOrmProvider(contextName),
         createEntityManagerProvider(options.scope, EntityManager, contextName),
-        ...(knex ? [createEntityManagerProvider(options?.scope, contextName ? getEntityManagerToken(contextName) : knex.SqlEntityManager, contextName)] : []),
-        ...(mongo ? [createEntityManagerProvider(options?.scope, contextName ? getEntityManagerToken(contextName) : mongo.MongoEntityManager, contextName)] : []),
+        ...(knex ? [createEntityManagerProvider(options?.scope, knex.SqlEntityManager, contextName)] : []),
+        ...(mongo ? [createEntityManagerProvider(options?.scope, mongo.MongoEntityManager, contextName)] : []),
       ],
       exports: [
         contextName ? getMikroORMToken(contextName) : MikroORM,

--- a/src/mikro-orm.providers.ts
+++ b/src/mikro-orm.providers.ts
@@ -1,9 +1,9 @@
 import { getEntityManagerToken, getMikroORMToken, getRepositoryToken, logger, MIKRO_ORM_MODULE_OPTIONS, REGISTERED_ENTITIES } from './mikro-orm.common';
 import type { AnyEntity, EntityName } from '@mikro-orm/core';
-import { ConfigurationLoader, EntityManager, MetadataStorage, MikroORM, Utils } from '@mikro-orm/core';
+import { ConfigurationLoader, EntityManager, MetadataStorage, MikroORM } from '@mikro-orm/core';
 
 import type { MikroOrmModuleAsyncOptions, MikroOrmModuleOptions, MikroOrmOptionsFactory } from './typings';
-import type { Provider } from '@nestjs/common';
+import type { Provider, Type } from '@nestjs/common';
 import { Scope } from '@nestjs/common';
 
 export function createMikroOrmProvider(contextName?: string): Provider {
@@ -32,19 +32,11 @@ export function createMikroOrmProvider(contextName?: string): Provider {
 
 export function createEntityManagerProvider(
   scope = Scope.DEFAULT,
-  entityManager: any = EntityManager,
+  entityManager: Type = EntityManager,
   contextName?: string,
 ): Provider<EntityManager> {
-  function getProvide() {
-    if (Utils.isString(entityManager)) {
-      return entityManager;
-    }
-
-    return contextName ? getEntityManagerToken(contextName) : entityManager;
-  }
-
   return {
-    provide: getProvide(),
+    provide: contextName ? getEntityManagerToken(contextName) : entityManager,
     scope,
     useFactory: (orm: MikroORM) => scope === Scope.DEFAULT ? orm.em : orm.em.fork(),
     inject: [contextName ? getMikroORMToken(contextName) : MikroORM],


### PR DESCRIPTION
After the discussion point of using just the entity manager injection token I noticed we can simplify the code even further