### PR TITLE
Module options cleanup

### DIFF
--- a/src/mikro-orm.module.ts
+++ b/src/mikro-orm.module.ts
@@ -4,7 +4,12 @@ import type { DynamicModule } from '@nestjs/common';
 import { Module } from '@nestjs/common';
 import { createMikroOrmRepositoryProviders } from './mikro-orm.providers';
 import { MikroOrmCoreModule } from './mikro-orm-core.module';
-import type { MikroOrmModuleAsyncOptions, MikroOrmModuleSyncOptions, MikroOrmMiddlewareModuleOptions } from './typings';
+import type {
+  MikroOrmModuleAsyncOptions,
+  MikroOrmModuleSyncOptions,
+  MikroOrmMiddlewareModuleOptions,
+  MikroOrmModuleFeatureOptions,
+} from './typings';
 import { REGISTERED_ENTITIES } from './mikro-orm.common';
 import { MikroOrmMiddlewareModule } from './mikro-orm-middleware.module';
 
@@ -25,9 +30,10 @@ export class MikroOrmModule {
     };
   }
 
-  static forFeature(options: EntityName<AnyEntity>[] | { entities?: EntityName<AnyEntity>[] }, contextName?: string): DynamicModule {
+  static forFeature(options: EntityName<AnyEntity>[] | MikroOrmModuleFeatureOptions, contextName?: string): DynamicModule {
     const entities = Array.isArray(options) ? options : (options.entities || []);
-    const providers = createMikroOrmRepositoryProviders(entities, contextName);
+    const name = Array.isArray(options) ? contextName : options.contextName;
+    const providers = createMikroOrmRepositoryProviders(entities, name);
 
     for (const e of entities) {
       if (!Utils.isString(e)) {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -41,6 +41,6 @@ export interface MikroOrmModuleAsyncOptions<D extends IDatabaseDriver = IDatabas
   contextName?: string;
   useExisting?: Type<MikroOrmOptionsFactory<D>>;
   useClass?: Type<MikroOrmOptionsFactory<D>>;
-  useFactory?: (...args: any[]) => Promise<MikroOrmModuleOptions<D>> | MikroOrmModuleOptions<D>;
+  useFactory?: (...args: any[]) => Promise<Omit<MikroOrmModuleOptions<D>, 'contextName'>> | Omit<MikroOrmModuleOptions<D>, 'contextName'>;
   inject?: any[];
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,4 @@
-import type { IDatabaseDriver, Options } from '@mikro-orm/core';
+import type { AnyEntity, EntityName, IDatabaseDriver, Options } from '@mikro-orm/core';
 import type { MiddlewareConsumer, ModuleMetadata, Scope, Type } from '@nestjs/common';
 import type { AbstractHttpAdapter } from '@nestjs/core';
 
@@ -25,6 +25,11 @@ export type MikroOrmModuleOptions<D extends IDatabaseDriver = IDatabaseDriver> =
   registerRequestContext?: boolean;
   autoLoadEntities?: boolean;
 } & Options<D> & MikroOrmMiddlewareModuleOptions;
+
+export interface MikroOrmModuleFeatureOptions {
+  entities?: EntityName<AnyEntity>[];
+  contextName?: string;
+}
 
 export interface MikroOrmOptionsFactory<D extends IDatabaseDriver = IDatabaseDriver> {
   createMikroOrmOptions(): Promise<MikroOrmModuleOptions<D>> | MikroOrmModuleOptions<D>;


### PR DESCRIPTION
Did not realise that the `forFeature` module method also took an options object so added the missing contextName so you can pass it in either way.

Also used omit MikroOrmModuleAsyncOptions useFactory as we do not need to define contextName again.