### PR TITLE
fix: multiple database connection with `autoLoadEntities`

### DIFF
--- a/src/mikro-orm.common.ts
+++ b/src/mikro-orm.common.ts
@@ -1,9 +1,8 @@
-import type { AnyEntity, EntityName } from '@mikro-orm/core';
+import type { EntityName } from '@mikro-orm/core';
 import { MikroORM, Utils } from '@mikro-orm/core';
 import { Inject, Logger } from '@nestjs/common';
 
 export const MIKRO_ORM_MODULE_OPTIONS = Symbol('mikro-orm-module-options');
-export const REGISTERED_ENTITIES = new Set<EntityName<AnyEntity>>();
 export const CONTEXT_NAMES: string[] = [];
 export const logger = new Logger(MikroORM.name);
 

--- a/src/mikro-orm.entities.storage.ts
+++ b/src/mikro-orm.entities.storage.ts
@@ -1,0 +1,30 @@
+import type { AnyEntity, EntityName } from '@mikro-orm/core';
+
+export class MikroOrmEntitiesStorage {
+
+  private static readonly storage = new Map<string, Set<EntityName<AnyEntity>>>();
+
+  static addEntity(entity: EntityName<AnyEntity>, contextName = 'default'): void {
+    let set = this.storage.get(contextName);
+    if (!set) {
+      set = new Set<EntityName<AnyEntity>>();
+      this.storage.set(contextName, set);
+    }
+
+    set.add(entity);
+  }
+
+  static getEntities(contextName = 'default') {
+    return this.storage.get(contextName)?.values() || [];
+  }
+
+  static clear(contextName = 'default') {
+    const set = this.storage.get(contextName);
+    if (!set) {
+      return;
+    }
+
+    set.clear();
+  }
+
+}

--- a/src/mikro-orm.entities.storage.ts
+++ b/src/mikro-orm.entities.storage.ts
@@ -4,7 +4,7 @@ export class MikroOrmEntitiesStorage {
 
   private static readonly storage = new Map<string, Set<EntityName<AnyEntity>>>();
 
-  static addEntity(entity: EntityName<AnyEntity>, contextName = 'default'): void {
+  static addEntity(entity: EntityName<AnyEntity>, contextName = 'default') {
     let set = this.storage.get(contextName);
     if (!set) {
       set = new Set<EntityName<AnyEntity>>();

--- a/src/mikro-orm.module.ts
+++ b/src/mikro-orm.module.ts
@@ -10,8 +10,8 @@ import type {
   MikroOrmMiddlewareModuleOptions,
   MikroOrmModuleFeatureOptions,
 } from './typings';
-import { REGISTERED_ENTITIES } from './mikro-orm.common';
 import { MikroOrmMiddlewareModule } from './mikro-orm-middleware.module';
+import { MikroOrmEntitiesStorage } from './mikro-orm.entities.storage';
 
 @Module({})
 export class MikroOrmModule {
@@ -32,12 +32,12 @@ export class MikroOrmModule {
 
   static forFeature(options: EntityName<AnyEntity>[] | MikroOrmModuleFeatureOptions, contextName?: string): DynamicModule {
     const entities = Array.isArray(options) ? options : (options.entities || []);
-    const name = Array.isArray(options) ? contextName : options.contextName;
+    const name = (Array.isArray(options) || contextName) ? contextName : options.contextName;
     const providers = createMikroOrmRepositoryProviders(entities, name);
 
     for (const e of entities) {
       if (!Utils.isString(e)) {
-        REGISTERED_ENTITIES.add(e);
+        MikroOrmEntitiesStorage.addEntity(e, name);
       }
     }
 

--- a/src/mikro-orm.providers.ts
+++ b/src/mikro-orm.providers.ts
@@ -1,22 +1,23 @@
-import { getEntityManagerToken, getMikroORMToken, getRepositoryToken, logger, MIKRO_ORM_MODULE_OPTIONS, REGISTERED_ENTITIES } from './mikro-orm.common';
+import { getEntityManagerToken, getMikroORMToken, getRepositoryToken, logger, MIKRO_ORM_MODULE_OPTIONS } from './mikro-orm.common';
 import type { AnyEntity, EntityName } from '@mikro-orm/core';
 import { ConfigurationLoader, EntityManager, MetadataStorage, MikroORM } from '@mikro-orm/core';
 
 import type { MikroOrmModuleAsyncOptions, MikroOrmModuleOptions, MikroOrmOptionsFactory } from './typings';
 import type { Provider, Type } from '@nestjs/common';
 import { Scope } from '@nestjs/common';
+import { MikroOrmEntitiesStorage } from './mikro-orm.entities.storage';
 
 export function createMikroOrmProvider(contextName?: string): Provider {
   return {
     provide: contextName ? getMikroORMToken(contextName) : MikroORM,
     useFactory: async (options?: MikroOrmModuleOptions) => {
       if (options?.autoLoadEntities) {
-        options.entities = [...(options.entities || []), ...REGISTERED_ENTITIES.values()];
-        options.entitiesTs = [...(options.entitiesTs || []), ...REGISTERED_ENTITIES.values()];
+        options.entities = [...(options.entities || []), ...MikroOrmEntitiesStorage.getEntities(contextName)];
+        options.entitiesTs = [...(options.entitiesTs || []), ...MikroOrmEntitiesStorage.getEntities(contextName)];
         delete options.autoLoadEntities;
       }
 
-      REGISTERED_ENTITIES.clear();
+      MikroOrmEntitiesStorage.clear(contextName);
 
       if (!options || Object.keys(options).length === 0) {
         const config = await ConfigurationLoader.getConfiguration();

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   env: {
+    'jasmine': true,
     'jest': true,
   },
   extends: [

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   env: {
-    'jasmine': true,
     'jest': true,
   },
   extends: [

--- a/tests/mikro-orm.module.test.ts
+++ b/tests/mikro-orm.module.test.ts
@@ -380,7 +380,7 @@ describe('MikroORM Module', () => {
             ...options,
           }),
           MikroOrmModule.forFeature([Foo], 'database1'),
-          MikroOrmModule.forFeature({ entities: [Bar], contextName: 'database2' }),
+          MikroOrmModule.forFeature({ entities: [Bar] }, 'database2'),
         ],
       }).compile();
 

--- a/tests/mikro-orm.module.test.ts
+++ b/tests/mikro-orm.module.test.ts
@@ -389,16 +389,8 @@ describe('MikroORM Module', () => {
       const repository1 = module.get<EntityRepository<Foo>>(getRepositoryToken(Foo, 'database1'));
       const repository2 = module.get<EntityRepository<Bar>>(getRepositoryToken(Bar, 'database2'));
 
-      try {
-        module.get<EntityRepository<Foo>>(getRepositoryToken(Foo, 'database2'));
-        fail('should not have come here');
-      } catch {}
-
-      try {
-        module.get<EntityRepository<Bar>>(getRepositoryToken(Bar, 'database1'));
-        fail('should not have come here');
-      } catch {}
-
+      expect(() => module.get<EntityRepository<Foo>>(getRepositoryToken(Foo, 'database2'))).toThrow();
+      expect(() => module.get<EntityRepository<Bar>>(getRepositoryToken(Bar, 'database1'))).toThrow();
       expect(orm1).toBeDefined();
       expect(repository1).toBeDefined();
       expect(orm2).toBeDefined();


### PR DESCRIPTION
As a user who does not use `autoLoadEntities` I discovered today multiple database connections currently does not work with it. I have added some extra tests around `autoLoadEntities` and created `MikroOrmEntitiesStorage ` to manage them.

I also updated `forFeature` to work with options and contextName param.