### PR TITLE
fix: return same EM fork for EM from core and driver packages

### DIFF
--- a/src/mikro-orm.providers.ts
+++ b/src/mikro-orm.providers.ts
@@ -36,6 +36,15 @@ export function createEntityManagerProvider(
   entityManager: Type = EntityManager,
   contextName?: string,
 ): Provider<EntityManager> {
+  if (!contextName && entityManager !== EntityManager) {
+    return {
+      provide: entityManager,
+      scope,
+      useFactory: (em: EntityManager) => em, // just a simle alias, unlike `useExisting` from nest, this works with request scopes too
+      inject: [EntityManager], // depend on the EM from core package
+    };
+  }
+
   return {
     provide: contextName ? getEntityManagerToken(contextName) : entityManager,
     scope,


### PR DESCRIPTION
Previously, there were 2 provides registered for the EM:
- one from core package
- one from each installed driver package (knex/mongo)

This brought issues with the nestjs request scopes, as the repositories depend on the core EM, while users usually inject from the driver package.

Now the driver specific provider just depends on the core EM and returns it, so both injection tokens behaves the same.

Closes #67 