### PR TITLE
feat: add clear storage method

### DIFF
--- a/src/mikro-orm.module.ts
+++ b/src/mikro-orm.module.ts
@@ -17,6 +17,14 @@ import { MikroOrmEntitiesStorage } from './mikro-orm.entities.storage';
 @Module({})
 export class MikroOrmModule {
 
+  /**
+   * Clears the entity storage. This is useful for testing purposes, when you want to isolate the tests.
+   * Keep in mind that this should be called when using a test runner that keeps the context alive between tests (like Vitest with threads disabled).
+   */
+  static clearStorage(contextName?: string) {
+    MikroOrmEntitiesStorage.clear(contextName);
+  }
+
   static forRoot(options?: MikroOrmModuleSyncOptions): DynamicModule {
     return {
       module: MikroOrmModule,


### PR DESCRIPTION
Hey, @B4nan. This simple method gives the client control over the entities' storage. This is related to #132. I noticed that the `clear()` method was actually unused in the repo. I'm adding that feature here in the hopes that you can publish a new version of the nest package sooner than the Mikro-orm, so I can start using this to continue working on my tests with Vitest. I appreciate the help so far!

Edit: I tested it locally, and it also fixes the issue for me (although not the ideal solution, that will work until you publish the changes in the mikro-orm/core package)