### PR TITLE
fix: await useFactory resolution when registering Mikro ORM with forRootAsync

### DIFF
--- a/src/mikro-orm.providers.ts
+++ b/src/mikro-orm.providers.ts
@@ -57,8 +57,8 @@ export function createMikroOrmAsyncOptionsProvider(options: MikroOrmModuleAsyncO
   if (options.useFactory) {
     return {
       provide: MIKRO_ORM_MODULE_OPTIONS,
-      useFactory: (...args: any[]) => {
-        const factoryOptions = options.useFactory!(...args);
+      useFactory: async (...args: any[]) => {
+        const factoryOptions = await options.useFactory!(...args);
         return options.contextName
           ? { contextName: options.contextName, ...factoryOptions }
           : factoryOptions;


### PR DESCRIPTION
When MikroORM's module is loaded with `forRootAsync`, it throws an error if `useFactory` is async or returns a promise :
```No driver specified, please fill in the `driver` option or use `defineConfig` helper (to define your ORM config) or `MikroORM` class (to call the `init` method) exported from the driver package (e.g. `import { defineConfig } from '@mikro-orm/mysql'; export defineConfig({ ... })`).```

This is understandable because `factoryOptions` is now a promise instead of the options object itself.

It makes sure that `createMikroOrmAsyncOptionsProvider` uses the result of the promise instead of the promise itself.