### PR TITLE
feat: allow passing an array of options into `forRoot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,21 @@ You can define multiple database connections by registering multiple `MikroOrmMo
 export class AppModule {}
 ```
 
+Since MikroORM v6.4, you can also define [multiple configurations](https://mikro-orm.io/docs/quick-start#configuration-file-structure) as part of a single ORM config. If you want to use such a combined config file, you need to destructure the result, since it will be also an array:
+
+```typescript
+@Module({
+  imports: [
+    // `config` exports an array of configs
+    ...MikroOrmModule.forRoot(config),
+    MikroOrmModule.forMiddleware()
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}
+```
+
 To access different `MikroORM`/`EntityManager` connections you have to use the new injection tokens `@InjectMikroORM()`/`@InjectEntityManager()` where you are required to pass the `contextName` in:
 
 ```ts

--- a/src/mikro-orm.module.ts
+++ b/src/mikro-orm.module.ts
@@ -10,6 +10,7 @@ import {
   MikroOrmModuleFeatureOptions,
   MikroOrmModuleSyncOptions,
   MikroOrmMiddlewareModuleOptions,
+  MaybePromise,
 } from './typings';
 
 @Module({})
@@ -23,11 +24,23 @@ export class MikroOrmModule {
     MikroOrmEntitiesStorage.clear(contextName);
   }
 
-  static forRoot(options?: MikroOrmModuleSyncOptions): DynamicModule | Promise<DynamicModule> {
+  static forRoot(options?: MikroOrmModuleSyncOptions): MaybePromise<DynamicModule>;
+  static forRoot(options?: MikroOrmModuleSyncOptions[]): MaybePromise<DynamicModule>[];
+  static forRoot(options?: MikroOrmModuleSyncOptions | MikroOrmModuleSyncOptions[]): MaybePromise<DynamicModule> | MaybePromise<DynamicModule>[] {
+    if (Array.isArray(options)) {
+      return options.map(o => MikroOrmCoreModule.forRoot(o));
+    }
+
     return MikroOrmCoreModule.forRoot(options);
   }
 
-  static forRootAsync(options: MikroOrmModuleAsyncOptions): DynamicModule | Promise<DynamicModule> {
+  static forRootAsync(options: MikroOrmModuleAsyncOptions): MaybePromise<DynamicModule>;
+  static forRootAsync(options: MikroOrmModuleAsyncOptions[]): MaybePromise<DynamicModule>[];
+  static forRootAsync(options: MikroOrmModuleAsyncOptions | MikroOrmModuleAsyncOptions[]): MaybePromise<DynamicModule> | MaybePromise<DynamicModule>[] {
+    if (Array.isArray(options)) {
+      return options.map(o => MikroOrmCoreModule.forRoot(o));
+    }
+
     return MikroOrmCoreModule.forRootAsync(options);
   }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -2,6 +2,8 @@ import type { AnyEntity, EntityName as CoreEntityName, EntitySchema, ForkOptions
 import type { MiddlewareConsumer, ModuleMetadata, Scope, Type } from '@nestjs/common';
 import type { AbstractHttpAdapter } from '@nestjs/core';
 
+export type MaybePromise<T> = T | Promise<T>;
+
 export interface NestMiddlewareConsumer extends MiddlewareConsumer {
   httpAdapter: AbstractHttpAdapter;
 }

--- a/tests/mikro-orm.module.test.ts
+++ b/tests/mikro-orm.module.test.ts
@@ -214,7 +214,7 @@ describe('MikroORM Module', () => {
     it('forFeature should return repository', async () => {
       const module = await Test.createTestingModule({
         imports: [
-          MikroOrmModule.forRoot(testOptions),
+          ...MikroOrmModule.forRoot([testOptions]),
           MikroOrmModule.forFeature([Foo]),
         ],
       }).compile();


### PR DESCRIPTION
Since MikroORM v6.4, you can also define [multiple configurations](https://mikro-orm.io/docs/quick-start#configuration-file-structure) as part of a single ORM config. If you want to use such a combined config file, you need to destructure the result, since it will be also an array:

```typescript
@Module({
  imports: [
    // `config` exports an array of configs
    ...MikroOrmModule.forRoot(config),
    MikroOrmModule.forMiddleware()
  ],
  controllers: [AppController],
  providers: [AppService],
})
export class AppModule {}
```

Closes #202