### PR TITLE
feat: add `driver` option to get around issues with `useFactory` and `inject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ export class PhotoService {
 }
 ```
 
+## Driver-specific imports
+
+When you try to inject the `EntityManager` or `MikroORM` symbols exported from the driver package, Nest.js needs to be aware of those typed. In other words, those driver specific exports need to be specifically registered in the DI container. This module uses automated discovery of the driver type in order to do that, but it fails to work when you use `useFactory` which requires some dependencies.
+
+Instead of relying on this discovery, you can provide the driver type explicitly:
+
+```typescript
+@Module({
+  imports: [
+    MikroOrmModule.forRootAsync({
+      useFactory: (configService: ConfigService) => configService.getOrThrow(ConfigKey.ORM),
+      inject: [ConfigService],
+      driver: PostgreSqlDriver,
+    }),
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}
+```
+
 ## Auto entities automatically
 
 Manually adding entities to the entities array of the connection options can be 
@@ -255,6 +276,7 @@ export class AppModule {}
 Or, if you're using the Async provider:
 ```typescript
 import { Scope } from '@nestjs/common';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 @Module({
   imports: [

--- a/src/mikro-orm-core.module.ts
+++ b/src/mikro-orm-core.module.ts
@@ -235,7 +235,10 @@ export class MikroOrmCoreModule implements NestModule, OnApplicationShutdown {
 
       return config?.getDriver().createEntityManager();
     } catch {
-      // ignore
+      if (options && 'useFactory' in options && 'inject' in options && (options.inject as unknown[]).length > 0) {
+        // eslint-disable-next-line no-console
+        console.warn('Support for driver specific imports in modules defined with `useFactory` and `inject` requires an explicit `driver` option. See https://github.com/mikro-orm/nestjs/pull/204');
+      }
     }
   }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,12 @@
-import type { AnyEntity, EntityName as CoreEntityName, EntitySchema, ForkOptions, IDatabaseDriver, Options } from '@mikro-orm/core';
+import type {
+  AnyEntity,
+  Constructor,
+  EntityName as CoreEntityName,
+  EntitySchema,
+  ForkOptions,
+  IDatabaseDriver,
+  Options,
+} from '@mikro-orm/core';
 import type { MiddlewareConsumer, ModuleMetadata, Scope, Type } from '@nestjs/common';
 import type { AbstractHttpAdapter } from '@nestjs/core';
 
@@ -83,6 +91,7 @@ export interface MikroOrmModuleAsyncOptions<D extends IDatabaseDriver = IDatabas
   useExisting?: Type<MikroOrmOptionsFactory<D>>;
   useClass?: Type<MikroOrmOptionsFactory<D>>;
   useFactory?: (...args: any[]) => Promise<Omit<MikroOrmModuleOptions<D>, 'contextName'>> | Omit<MikroOrmModuleOptions<D>, 'contextName'>;
+  driver?: Constructor<D>;
   inject?: any[];
 }
 

--- a/tests/mikro-orm.module.test.ts
+++ b/tests/mikro-orm.module.test.ts
@@ -212,6 +212,23 @@ describe('MikroORM Module', () => {
       await module.get<MikroORM>(MikroORM).close();
     });
 
+    it('useFactory with injection prints a warning', async () => {
+      const warnSpy = jest.spyOn(console, 'warn');
+      warnSpy.mockImplementation();
+      const module = await Test.createTestingModule({
+        imports: [MikroOrmModule.forRootAsync({
+          useFactory: (logger: Logger) => ({
+            ...testOptions,
+            logger: logger.log.bind(logger),
+          }),
+          inject: ['my-logger'],
+          providers: [myLoggerProvider],
+        })],
+      }).compile();
+      expect(warnSpy).toBeCalledWith('Support for driver specific imports in modules defined with `useFactory` and `inject` requires an explicit `driver` option. See https://github.com/mikro-orm/nestjs/pull/204');
+      await module.get<MikroORM>(MikroORM).close();
+    });
+
     it('forFeature should return repository', async () => {
       const module = await Test.createTestingModule({
         imports: [

--- a/tests/mikro-orm.module.test.ts
+++ b/tests/mikro-orm.module.test.ts
@@ -199,6 +199,7 @@ describe('MikroORM Module', () => {
             ...testOptions,
             logger: logger.log.bind(logger),
           }),
+          driver: SqliteDriver,
           inject: ['my-logger'],
           providers: [myLoggerProvider],
         })],
@@ -316,24 +317,26 @@ describe('MikroORM Module', () => {
     it('forRootAsync :useFactory', async () => {
       const module = await Test.createTestingModule({
         imports: [
-          MikroOrmModule.forRootAsync({
-            contextName: 'database1',
-            useFactory: (logger: Logger) => ({
-              ...testOptions,
-              logger: logger.log.bind(logger),
-            }),
-            inject: ['my-logger'],
-            providers: [myLoggerProvider],
-          }),
-          MikroOrmModule.forRootAsync({
-            contextName: 'database2',
-            useFactory: (logger: Logger) => ({
-              ...testOptions,
-              logger: logger.log.bind(logger),
-            }),
-            inject: ['my-logger'],
-            providers: [myLoggerProvider],
-          }),
+          ...MikroOrmModule.forRootAsync([
+            {
+              contextName: 'database1',
+              useFactory: (logger: Logger) => ({
+                ...testOptions,
+                logger: logger.log.bind(logger),
+              }),
+              inject: ['my-logger'],
+              providers: [myLoggerProvider],
+            },
+            {
+              contextName: 'database2',
+              useFactory: (logger: Logger) => ({
+                ...testOptions,
+                logger: logger.log.bind(logger),
+              }),
+              inject: ['my-logger'],
+              providers: [myLoggerProvider],
+            },
+          ]),
         ],
       }).compile();
 


### PR DESCRIPTION
When you try to inject the `EntityManager` or `MikroORM` symbols exported from the driver package, Nest.js needs to be aware of those typed. In other words, those driver specific exports need to be specifically registered in the DI container. This module uses automated discovery of the driver type in order to do that, but it fails to work when you use `useFactory` which requires some dependencies.

Instead of relying on this discovery, you can provide the driver type explicitly:

```typescript
@Module({
  imports: [
    MikroOrmModule.forRootAsync({
      useFactory: (configService: ConfigService) => configService.getOrThrow(ConfigKey.ORM),
      inject: [ConfigService],
      driver: PostgreSqlDriver,
    }),
  ],
  controllers: [AppController],
  providers: [AppService],
})
export class AppModule {}
```

Closes #184
Closes #195