### PR TITLE
fix: support custom repositories with `EntitySchema`/`defineEntity`

### DIFF
--- a/src/mikro-orm.providers.ts
+++ b/src/mikro-orm.providers.ts
@@ -1,4 +1,4 @@
-import { EntityManager, MetadataStorage, MikroORM, type AnyEntity, type ForkOptions } from '@mikro-orm/core';
+import { EntityManager, EntitySchema, MetadataStorage, MikroORM, type AnyEntity, type ForkOptions } from '@mikro-orm/core';
 import { Scope, type InjectionToken, type Provider, type Type } from '@nestjs/common';
 
 import {
@@ -117,7 +117,7 @@ export function createMikroOrmRepositoryProviders(entities: EntityName<AnyEntity
   const inject = contextName ? getEntityManagerToken(contextName) : EntityManager;
 
   (entities || []).forEach(entity => {
-    const meta = metadata.find(meta => meta.class === entity);
+    const meta = entity instanceof EntitySchema ? entity.meta : metadata.find(meta => meta.class === entity);
     const repository = meta?.repository as unknown as (() => InjectionToken) | undefined;
 
     if (repository) {

--- a/tests/entities/baz.entity.ts
+++ b/tests/entities/baz.entity.ts
@@ -1,0 +1,47 @@
+import { EntityRepository, EntitySchema, defineEntity, p } from '@mikro-orm/core';
+
+// EntitySchema test
+export interface IBaz {
+  id: number;
+  name: string;
+}
+
+export class BazRepository extends EntityRepository<IBaz> {
+
+  customMethod(): string {
+    return 'custom';
+  }
+
+}
+
+export const Baz = new EntitySchema<IBaz>({
+  name: 'Baz',
+  repository: () => BazRepository,
+  properties: {
+    id: { type: 'number', primary: true },
+    name: { type: 'string' },
+  },
+});
+
+// defineEntity test
+export interface IQux {
+  id: number;
+  title: string;
+}
+
+export class QuxRepository extends EntityRepository<IQux> {
+
+  anotherCustomMethod(): string {
+    return 'another-custom';
+  }
+
+}
+
+export const Qux = defineEntity({
+  name: 'Qux',
+  repository: () => QuxRepository,
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+  },
+});

--- a/tests/mikro-orm.module.test.ts
+++ b/tests/mikro-orm.module.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@mikro-orm/nestjs';
 import { Bar } from './entities/bar.entity.js';
 import { Foo } from './entities/foo.entity.js';
+import { Baz, BazRepository, Qux, QuxRepository } from './entities/baz.entity.js';
 
 const testOptions = defineConfig({
   dbName: ':memory:',
@@ -91,7 +92,7 @@ describe('MikroORM Module', () => {
         imports: [MikroOrmModule.forRoot(testOptions)],
       }).compile();
 
-      const orm = module.get<MikroORM>(MikroORM);
+      const orm = module.get(MikroORM);
       expect(orm).toBeDefined();
       expect(orm.config.get('contextName')).toBe('default');
       expect(module.get<EntityManager>(EntityManager)).toBeDefined();
@@ -109,7 +110,7 @@ describe('MikroORM Module', () => {
         ],
       }).compile();
 
-      const orm = module.get<MikroORM>(MikroORM);
+      const orm = module.get(MikroORM);
       expect(orm).toBeDefined();
       expect(orm.config.get('contextName')).toBe('default');
       expect(module.get<EntityManager>(EntityManager)).toBeDefined();
@@ -127,7 +128,7 @@ describe('MikroORM Module', () => {
         ],
       }).compile();
 
-      const orm = module.get<MikroORM>(MikroORM);
+      const orm = module.get(MikroORM);
       expect(orm).toBeDefined();
       expect(orm.config.get('contextName')).toBe('default');
       expect(module.get<EntityManager>(EntityManager)).toBeDefined();
@@ -149,7 +150,7 @@ describe('MikroORM Module', () => {
         ],
       }).compile();
 
-      const orm = module.get<MikroORM>(MikroORM);
+      const orm = module.get(MikroORM);
       expect(orm).toBeDefined();
       expect(orm.config.get('contextName')).toBe('default');
       expect(module.get<EntityManager>(EntityManager)).toBeDefined();
@@ -261,7 +262,7 @@ describe('MikroORM Module', () => {
         imports: [...MikroOrmModule.forRoot([testOptions]), MikroOrmModule.forFeature([Foo])],
       }).compile();
 
-      const orm = module.get<MikroORM>(MikroORM);
+      const orm = module.get(MikroORM);
       const entityManager = module.get<EntityManager>(EntityManager);
       const repository = module.get<EntityRepository<Foo>>(getRepositoryToken(Foo));
 
@@ -285,13 +286,57 @@ describe('MikroORM Module', () => {
         ],
       }).compile();
 
-      const orm = module.get<MikroORM>(MikroORM);
+      const orm = module.get(MikroORM);
       const entityManager = module.get<EntityManager>(EntityManager);
       const repository = module.get<EntityRepository<Foo>>(getRepositoryToken(Foo));
 
       expect(orm).toBeDefined();
       expect(entityManager).toBeDefined();
       expect(repository).toBeDefined();
+
+      await orm.close();
+    });
+
+    it('forFeature should return custom repository for EntitySchema (GH6701)', async () => {
+      const module = await Test.createTestingModule({
+        imports: [
+          MikroOrmModule.forRoot({
+            ...testOptions,
+            entities: [Baz],
+          }),
+          MikroOrmModule.forFeature([Baz]),
+        ],
+      }).compile();
+
+      const orm = module.get(MikroORM);
+      const repository = module.get(BazRepository);
+
+      expect(orm).toBeDefined();
+      expect(repository).toBeDefined();
+      expect(repository).toBeInstanceOf(BazRepository);
+      expect(repository.customMethod()).toBe('custom');
+
+      await orm.close();
+    });
+
+    it('forFeature should return custom repository for defineEntity (GH6701)', async () => {
+      const module = await Test.createTestingModule({
+        imports: [
+          MikroOrmModule.forRoot({
+            ...testOptions,
+            entities: [Qux],
+          }),
+          MikroOrmModule.forFeature([Qux]),
+        ],
+      }).compile();
+
+      const orm = module.get(MikroORM);
+      const repository = module.get(QuxRepository);
+
+      expect(orm).toBeDefined();
+      expect(repository).toBeDefined();
+      expect(repository).toBeInstanceOf(QuxRepository);
+      expect(repository.anotherCustomMethod()).toBe('another-custom');
 
       await orm.close();
     });


### PR DESCRIPTION
When using `forFeature()` with entities defined via `EntitySchema` or `defineEntity`, custom repositories were not being registered as providers. This was because the metadata lookup only checked for class-based entities.

Now the code properly handles `EntitySchema` instances by accessing their metadata directly via `entity.meta`.

Closes mikro-orm/mikro-orm#6701