### PR TITLE
ci: prepare for v7 stable release [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: |
-          yarn copy --canary=major
+          yarn copy --canary=patch
           git commit -am 'chore: bump canary versions [skip ci]'
           cd dist
           npm publish --tag=next


### PR DESCRIPTION
## Summary
- Switch canary bump from `major` to `patch` (post-release canaries: `7.0.1-dev.X` instead of `8.0.0-dev.X`)

Merge after the stable 7.0.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)