### PR TITLE
fix: accept concrete driver/EM/entities types in module options

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -56,7 +56,7 @@ export type MikroOrmModuleOptions<D extends IDatabaseDriver = IDatabaseDriver> =
    * @default false
    */
   autoLoadEntities?: boolean;
-} & Partial<Options<D, any, any>> &
+} & Partial<Options<any, any, any>> &
   MikroOrmMiddlewareModuleOptions;
 
 export interface MikroOrmModuleFeatureOptions {

--- a/tests/readonly-entities.types.test-d.ts
+++ b/tests/readonly-entities.types.test-d.ts
@@ -1,34 +1,51 @@
-import type { MikroOrmModuleAsyncOptions, MikroOrmModuleSyncOptions, MikroOrmOptionsFactory, MikroOrmModuleOptions } from '@mikro-orm/nestjs';
+import type {
+  MikroOrmModuleAsyncOptions,
+  MikroOrmModuleSyncOptions,
+  MikroOrmOptionsFactory,
+  MikroOrmModuleOptions,
+} from '@mikro-orm/nestjs';
 import { defineConfig, SqliteDriver } from '@mikro-orm/sqlite';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 
 class A {}
 class B {}
 
-const cfgPaths    = defineConfig({ entities: ['entities'], dbName: 'x' });
-const cfgClasses  = defineConfig({ entities: [A, B],        dbName: 'x' });
+const cfgPaths = defineConfig({ entities: ['entities'], dbName: 'x' });
+const cfgClasses = defineConfig({ entities: [A, B], dbName: 'x' });
 const cfgReadonly = defineConfig({ entities: [A, B] as const, dbName: 'x' });
 
-MikroOrmModule.forRoot(cfgPaths);
-MikroOrmModule.forRoot(cfgClasses);
-MikroOrmModule.forRoot(cfgReadonly);
-
-MikroOrmModule.forRootAsync({ useFactory: () => cfgPaths });
-MikroOrmModule.forRootAsync({ useFactory: () => cfgClasses });
-MikroOrmModule.forRootAsync({ useFactory: () => cfgReadonly });
-MikroOrmModule.forRootAsync({ useFactory: async () => cfgReadonly });
-
-MikroOrmModule.forRootAsync({ driver: SqliteDriver, useFactory: () => cfgReadonly });
-
 class Factory implements MikroOrmOptionsFactory {
-  createMikroOrmOptions() { return cfgReadonly; }
+  createMikroOrmOptions() {
+    return cfgReadonly;
+  }
 }
 class FactoryAsync implements MikroOrmOptionsFactory {
-  async createMikroOrmOptions() { return cfgReadonly; }
+  async createMikroOrmOptions() {
+    return cfgReadonly;
+  }
 }
-MikroOrmModule.forRootAsync({ useClass: Factory });
-MikroOrmModule.forRootAsync({ useExisting: Factory });
 
-const _o1: MikroOrmModuleSyncOptions = cfgReadonly;
-const _o2: MikroOrmModuleOptions = cfgReadonly;
-const _o3: MikroOrmModuleAsyncOptions = { useFactory: () => cfgReadonly };
+// type-only — never executed; the file's purpose is to fail the build if these
+// arguments stop type-checking against the module API.
+export const _typecheck = () => {
+  void MikroOrmModule.forRoot(cfgPaths);
+  void MikroOrmModule.forRoot(cfgClasses);
+  void MikroOrmModule.forRoot(cfgReadonly);
+
+  void MikroOrmModule.forRootAsync({ useFactory: () => cfgPaths });
+  void MikroOrmModule.forRootAsync({ useFactory: () => cfgClasses });
+  void MikroOrmModule.forRootAsync({ useFactory: () => cfgReadonly });
+  void MikroOrmModule.forRootAsync({ useFactory: async () => cfgReadonly });
+
+  void MikroOrmModule.forRootAsync({ driver: SqliteDriver, useFactory: () => cfgReadonly });
+
+  void MikroOrmModule.forRootAsync({ useClass: Factory });
+  void MikroOrmModule.forRootAsync({ useClass: FactoryAsync });
+  void MikroOrmModule.forRootAsync({ useExisting: Factory });
+
+  const _o1: MikroOrmModuleSyncOptions = cfgReadonly;
+  const _o2: MikroOrmModuleOptions = cfgReadonly;
+  const _o3: MikroOrmModuleAsyncOptions = { useFactory: () => cfgReadonly };
+
+  return [_o1, _o2, _o3];
+};

--- a/tests/readonly-entities.types.test-d.ts
+++ b/tests/readonly-entities.types.test-d.ts
@@ -1,0 +1,34 @@
+import type { MikroOrmModuleAsyncOptions, MikroOrmModuleSyncOptions, MikroOrmOptionsFactory, MikroOrmModuleOptions } from '@mikro-orm/nestjs';
+import { defineConfig, SqliteDriver } from '@mikro-orm/sqlite';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+
+class A {}
+class B {}
+
+const cfgPaths    = defineConfig({ entities: ['entities'], dbName: 'x' });
+const cfgClasses  = defineConfig({ entities: [A, B],        dbName: 'x' });
+const cfgReadonly = defineConfig({ entities: [A, B] as const, dbName: 'x' });
+
+MikroOrmModule.forRoot(cfgPaths);
+MikroOrmModule.forRoot(cfgClasses);
+MikroOrmModule.forRoot(cfgReadonly);
+
+MikroOrmModule.forRootAsync({ useFactory: () => cfgPaths });
+MikroOrmModule.forRootAsync({ useFactory: () => cfgClasses });
+MikroOrmModule.forRootAsync({ useFactory: () => cfgReadonly });
+MikroOrmModule.forRootAsync({ useFactory: async () => cfgReadonly });
+
+MikroOrmModule.forRootAsync({ driver: SqliteDriver, useFactory: () => cfgReadonly });
+
+class Factory implements MikroOrmOptionsFactory {
+  createMikroOrmOptions() { return cfgReadonly; }
+}
+class FactoryAsync implements MikroOrmOptionsFactory {
+  async createMikroOrmOptions() { return cfgReadonly; }
+}
+MikroOrmModule.forRootAsync({ useClass: Factory });
+MikroOrmModule.forRootAsync({ useExisting: Factory });
+
+const _o1: MikroOrmModuleSyncOptions = cfgReadonly;
+const _o2: MikroOrmModuleOptions = cfgReadonly;
+const _o3: MikroOrmModuleAsyncOptions = { useFactory: () => cfgReadonly };


### PR DESCRIPTION
`MikroOrmModuleOptions` widens the inner `Options` generics to `any` so configs produced by driver-specific `defineConfig` (e.g. `Options<PostgreSqlDriver, …, readonly […]>`) flow through `forRoot` / `forRootAsync` / `MikroOrmOptionsFactory` without structural mismatches against the default `IDatabaseDriver`. The module surface doesn't read the inner driver/EM/entities types, so widening them is a no-op for consumers.

This also unblocks `entities: [...] as const` arrays, which v7.1 `Options.entities` accepts via its `readonly` `Entities` generic — they previously rebounded off `Partial<Options<D, any, any>>` because the third arg was the only `any` while the first stayed nominally tied to `IDatabaseDriver`.

Added `tests/readonly-entities.types.test-d.ts` to lock in coverage for `forRoot`, `forRootAsync` (useFactory / useClass / useExisting / explicit `driver:`), and `MikroOrmOptionsFactory` against string paths, mutable class arrays, and `as const` arrays.

Closes #255